### PR TITLE
Handle serials with a single missing leading zero.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ This tool queries the published Mozilla CRLite database to determine certificate
 
 It maintains a local database in your `~/.crlitedb/` folder, which is updated when older than six hours.
 
+It works on a best-effort basis, and certificates with malformed serial numbers or other serious encoding issues might not be identified correctly, which would lead to false negatives. For a more bulletproof implementation of a CRLite decoder, you might want to consider building one atop [the rust-cascade](https://github.com/mozilla/rust-cascade) project, or simply rework the ASN.1 parsing here to reveal the exact values from the encoding without converting to intermediate Python types.
+
 Install from [PyPi](https://pypi.org/project/moz-crlite-query/):
 
 ```sh

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="moz_crlite_query",
-    version="0.3.8",
+    version="0.4.0",
     description="Query CRLite for a certificate, or certificate information",
     long_description="Use this tool to download and maintain CRLite information from "
     + "Mozilla's Remote Settings infrastructure, and query it.",


### PR DESCRIPTION
Python doesn't like integer values with leading zeroes, and I can't seem to
make pyasn.1 provide the serial number in a format where I can obtain the raw
DER-encoding.

This works around the problem by testing the top bit after big-endian-ing the
value, and if it's set, retry the filter checks with a prepended leading zero.

Fixes #15

