### PR TITLE
fixes #18: use filter_date() instead of latest_covered_date()

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="moz_crlite_query",
-    version="0.4.1",
+    version="0.4.2",
     description="Query CRLite for a certificate, or certificate information",
     long_description="Use this tool to download and maintain CRLite information from "
     + "Mozilla's Remote Settings infrastructure, and query it.",


### PR DESCRIPTION
Certificates being too new or expired has to do with the date of the filter,
and not any of the stashes.