### PR TITLE
  Use Remote Settings new STAGE URL

### DIFF
--- a/crlite_query/query_cli.py
+++ b/crlite_query/query_cli.py
@@ -16,7 +16,7 @@ crlite_collection_prod = (
     + "/collections/cert-revocations/records"
 )
 crlite_collection_stage = (
-    "https://settings.stage.mozaws.net/v1/buckets/security-state"
+    "https://settings-cdn.stage.mozaws.net/v1/buckets/security-state"
     + "/collections/cert-revocations/records"
 )
 intermediates_collection_prod = (


### PR DESCRIPTION
In [Bug 1594573](https://bugzilla.mozilla.org/show_bug.cgi?id=1594573), we fixed some inconsistencies between our prod and stage URLs.

This is the new URL to be used for the STAGE public server.